### PR TITLE
Use Flask.teardown_appcontext if available

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest-cov
 tox
+mock

--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -157,8 +157,16 @@ class SQLAlchemy(object):
         hooks to call ``db.session.remove()`` after each response, and
         ``db.session.rollback()`` if an error occurs.
         """
-        if hasattr(app, 'after_request'):
-            app.after_request(shutdown)
+        # 0.9 and later
+        if hasattr(app, 'teardown_appcontext'):
+            teardown = app.teardown_appcontext
+        # 0.7 to 0.8
+        elif hasattr(app, 'teardown_request'):
+            teardown = app.teardown_request
+        # Older Flask versions
+        else:
+            teardown = app.after_request
+        teardown(shutdown)
         if hasattr(app, 'on_exception'):
             app.on_exception(rollback)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from datetime import datetime
+import mock
 import pytest
 
 from sqlalchemy_wrapper import SQLAlchemy
@@ -39,32 +40,47 @@ def test_define_table():
 
 def test_init_app():
 
+    teardown_appcontext_spy = mock.Mock()
+    after_request_spy = mock.Mock()
+    on_exception_spy = mock.Mock()
+    hook_spy = mock.Mock()
+
+    # Flask-like (>=0.9)
+    class AppWithTearDownAppContext(object):
+        def teardown_appcontext(self, f):
+            teardown_appcontext_spy()
+
+    # Old Flask- or Bottle-like
     class App(object):
 
-        def teardown_appcontext(self, f):
-            f()
-
         def after_request(self, f):
-            f()
+            after_request_spy()
 
         def on_exception(self, f):
-            f()
+            on_exception_spy()
 
         def hook(self, name):
             def decorator(f):
-                f()
+                hook_spy()
             return decorator
 
     app = App()
     db = SQLAlchemy(URI1)
     db.init_app(app)
     assert app.databases
+    after_request_spy.assert_called_once()
+    on_exception_spy.assert_called_once()
+    hook_spy.assert_called_once()
 
     app = App()
     db = SQLAlchemy(URI1, app)
     assert app.databases
     db.init_app(app)
     assert len(app.databases) == 1
+
+    app = AppWithTearDownAppContext()
+    db = SQLAlchemy(URI1, app)
+    teardown_appcontext_spy.assert_called_once()
 
 
 def test_query():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,6 +41,9 @@ def test_init_app():
 
     class App(object):
 
+        def teardown_appcontext(self, f):
+            f()
+
         def after_request(self, f):
             f()
 


### PR DESCRIPTION
`Flask.teardown_appcontext` is the preferred hook for database disconnection: https://github.com/mitsuhiko/flask/blob/7d506f2408520ecb21025f93d9ece00431004501/flask/app.py#L426-L432 .

This also improves the tests to assert that the correct hooks are called when calling `SQLAlchemy.init_app`.