### PR TITLE
Allow passing "isolation_level" to create_engine()

### DIFF
--- a/sqlalchemy_wrapper/main.py
+++ b/sqlalchemy_wrapper/main.py
@@ -69,7 +69,7 @@ class SQLAlchemy(object):
 
     def __init__(self, uri='sqlite://', app=None, echo=False,
                  pool_size=None, pool_timeout=None, pool_recycle=None,
-                 convert_unicode=True, query_cls=BaseQuery,
+                 convert_unicode=True, isolation_level=None, query_cls=BaseQuery,
                  record_queries=False, **session_options):
         self.uri = uri
         self.record_queries = record_queries
@@ -80,6 +80,7 @@ class SQLAlchemy(object):
             pool_timeout=pool_timeout,
             pool_recycle=pool_recycle,
             convert_unicode=convert_unicode,
+            isolation_level=isolation_level,
         )
 
         self.connector = None


### PR DESCRIPTION
Makes it easier to to configure applications that need to work with specific "isolation_level"